### PR TITLE
Supporting childless item

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A really lightweight, symantic, super simple accordion for React
 - [x] Multiple/Single expanded option
 - [ ] Default theme
 - [x] Write test for passing open prop
-- [ ] Support childless item
+- [x] Support childless item
 - [ ] CI/CD
 - [x] GitHub Pages Demo
 - [ ] Contributing/Security documents

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -18,6 +18,10 @@ const data = [
     name: 'A Third Option',
     heading: 'A Third Option',
     child: <span>Just a third option</span>,
+  },
+  {
+    name: 'No child',
+    heading: 'No child',
   }
 ];
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, SyntheticEvent, useState } from 'react';
 interface Item {
   name: string,
   heading: ReactNode,
-  child: ReactNode,
+  child?: ReactNode,
   open?: boolean,
 }
 
@@ -20,10 +20,17 @@ export function ReactAccordion(props: ReactAccordionProps) {
     <ul>
       {items.map((item, index) => (
         <li key={item.name}>
-          <details aria-label={item.name} open={item.open}>
-            <summary onClick={(event: SyntheticEvent) => typeof onClick === 'function' && onClick(event, index)}>{item.heading}</summary>
-            {item.child}
-          </details>
+          {item.child
+            ? (
+              <details aria-label={item.name} open={item.open}>
+                <summary
+                  onClick={(event: SyntheticEvent) => typeof onClick === 'function' && onClick(event, index)}
+                >
+                  {item.heading}
+                </summary>
+                {item.child}
+              </details>
+            ) : (<summary>{item.heading}</summary>)}
         </li>
       ))}
     </ul>
@@ -40,7 +47,7 @@ export function SingleItemOpenAccordion(props: { items: Item[] }) {
   }
   const [openItemIndex, setOpenItemIndex] = useState<number | null>(initialOpenItem);
 
-  const handleClick = (event: SyntheticEvent, index:number) => {
+  const handleClick = (event: SyntheticEvent, index: number) => {
     event.preventDefault();
     setOpenItemIndex(openItemIndex === index ? null : index);
   };


### PR DESCRIPTION
If item is childless, no need to render `<details>` and therefore no marker.